### PR TITLE
fix: tell eslint to check .tx and .jsx files too

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "eslint": "eslint --ext .tsx,.js ./src/",
+    "eslint": "eslint --ext .ts,.tsx,.js,.jsx ./src/",
     "lint": "npm run eslint",
     "format": "prettier --check --write ./src/**/*.{tsx,ts}",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
Add additional extensions for cheking during lintering process.