### PR TITLE
fix: build container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore by default
+**/*
+
+# Root directory
+!LICENSE
+!jest.config.js
+!__mocks__
+!package.json
+!package-lock.json
+!styleguide.config.js
+!stylePaths.js
+!tsconfig.json
+!webpack.common.js
+!webpack.dev.js
+!webpack.prod.js
+
+# Source directory
+!src
+!src/**
+!src/**/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@
 !.github/**
 !.github/**/*
 
+# Add deploy directory
+!deploy
+!deploy/**
+!deploy/**/*
+
 # Add docs
 !docs
 !docs/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,34 @@
-FROM  ... as builder
+# https://docs.docker.com/reference/dockerfile/
+# https://www.docker.com/blog/how-to-dockerize-react-app/
 
+# https://hub.docker.com/_/node/
+
+###############################################################################
+# Stage builder
+###############################################################################
+FROM docker.io/node:22-alpine AS builder
+
+WORKDIR /app
+
+# Prepare cache layer
+COPY package* .
+RUN npm install --frozen-lockfile && npm cache clean --force
+
+# Build the application
+COPY . .
+RUN npm run build
+
+###############################################################################
+# Stage production
+###############################################################################
 
 # The final target will copy the resulting dist/ directory from the builder
 # container to the target directory where the nginx, caddyserver or other
 # http server will serve the files from
-FROM ...
-COPY --from=builder SOURCE/dist TARGET/dist
+FROM docker.io/nginx:alpine AS production
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
 

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,0 +1,13 @@
+# https://docs.docker.com/reference/compose-file/
+services:
+  frontend:
+    build:
+      image: ${CONTAINER_IMAGE_BASE}:${CONTAINER_TAG}
+      context: ../
+      dockerfile: Dockerfile
+    volumes:
+      - ./app:/app
+    ports:
+      - "9000:80"
+    environment:
+      NODE_ENV: development

--- a/scripts/mk/compose.mk
+++ b/scripts/mk/compose.mk
@@ -19,45 +19,20 @@ endif
 
 COMPOSE_FILE ?= $(PROJECT_DIR)/deploy/docker-compose.yaml
 
-COMPOSE_VARS_DATABASE=\
-	DATABASE_USER="$(DATABASE_USER)" \
-	DATABASE_PASSWORD="$(DATABASE_PASSWORD)" \
-	DATABASE_NAME="$(DATABASE_NAME)" \
-	DATABASE_EXTERNAL_PORT="$(DATABASE_EXTERNAL_PORT)"
-
-COMPOSE_VARS_DB_MIGRATE=\
-	DATABASE_USER="$(DATABASE_USER)" \
-	DATABASE_PASSWORD="$(DATABASE_PASSWORD)" \
-	DATABASE_NAME="$(DATABASE_NAME)" \
-	DATABASE_HOST="$(DATABASE_HOST)" \
-	DATABASE_PORT="$(DATABASE_EXTERNAL_PORT)"
-
-COMPOSE_VARS_KAFKA=\
-	KAFKA_CONFIG_DIR=$(KAFKA_CONFIG_DIR) \
-	KAFKA_DATA_DIR=$(KAFKA_DATA_DIR) \
-	ZOOKEEPER_CLIENT_PORT=$(ZOOKEEPER_CLIENT_PORT) \
-	KAFKA_TOPICS=$(KAFKA_TOPICS)
-
-COMPOSE_VARS_APP=\
-    APP_SECRET="$(APP_SECRET)" \
-    APP_VALIDATE_API=$(APP_VALIDATE_API) \
-    APP_TOKEN_EXPIRATION_SECONDS=$(APP_TOKEN_EXPIRATION_SECONDS)
+COMPOSE_VARS_APP=
 
 COMPOSE_VARS= \
 	CONTAINER_IMAGE_BASE="$(CONTAINER_IMAGE_BASE)" \
 	CONTAINER_IMAGE_TAG="$(CONTAINER_IMAGE_TAG)" \
-	$(COMPOSE_VARS_DATABASE) \
-	$(COMPOSE_VARS_KAFKA) \
 	$(COMPOSE_VARS_APP)
 
 
 .PHONY: compose-up
 compose-up: ## Start local infrastructure
-	source .venv/bin/activate && \
 	$(COMPOSE_VARS) \
 	    $(COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) up -d
-	$(MAKE) .compose-wait-db
-	$(MAKE) $(COMPOSE_VARS_DB_MIGRATE) db-migrate-up
+	@#$(MAKE) .compose-wait-db
+	@#$(MAKE) $(COMPOSE_VARS_DB_MIGRATE) db-migrate-up
 
 .PHONY: .compose-wait-db
 .compose-wait-db:
@@ -69,29 +44,24 @@ compose-up: ## Start local infrastructure
 
 .PHONY: compose-down
 compose-down: ## Stop local infrastructure
-	source .venv/bin/activate && \
 	$(COMPOSE_VARS) \
 	    $(COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) down --volumes
 
 .PHONY: compose-build
 compose-build: ## Build the images at docker-compose.yaml
-	source .venv/bin/activate && \
 	$(COMPOSE_VARS) \
 	    $(COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) build
 
 .PHONY: compose-pull
 compose-pull: ## Pull images
-	source .venv/bin/activate && \
 	$(COMPOSE_VARS) \
 	    $(COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) pull
 
 .PHONY: compose-logs
 compose-logs: ## Print out infrastructure logs
-	source .venv/bin/activate && \
 	$(COMPOSE_VARS) \
 	    $(COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) logs
 
 .PHONY: compose-clean
 compose-clean: compose-down  ## Stop and clean local infrastructure
-	source .venv/bin/activate && \
 	$(CONTAINER_ENGINE) volume prune --force

--- a/scripts/mk/printvars.mk
+++ b/scripts/mk/printvars.mk
@@ -9,4 +9,4 @@ printvars: ## Print variable name and values
 
 .PHONY: printenvcfg
 printenvcfg: ## Print the environment the resulting exported environment
-	@env | grep -P -e '^(APP|CONFIG_PATH|DATABASE|KAFKA|LOGGING|WEB)(_.*)?=' | sort
+	@env | grep -P -e '^(APP|CONFIG|DATABASE|KAFKA|LOGGING|WEB)(_.*)?=' | sort

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -7,37 +7,19 @@
 ##
 APP_NAME ?= todo
 export APP_NAME
+APP_COMPONENT ?= frontend
+export APP_COMPONENT
 
 BIN ?= bin
 PATH := $(CURDIR)/$(BIN):$(PATH)
 export PATH
 
-CONFIG_PATH ?= $(PROJECT_DIR)/configs
-export CONFIG_PATH
-CONFIG_YAML := $(CONFIG_PATH)/config.yaml
-
 COMPOSE_FILE ?= $(PROJECT_DIR)/deploy/docker-compose.yaml
 
+ifeq ($(QUAY_USER),)
+error(QUAY_USER is not defined)
+endif
 CONTAINER_IMAGE_BASE ?= quay.io/$(firstword $(subst +, ,$(QUAY_USER)))/$(APP_NAME)-$(APP_COMPONENT)
 
 # Application specific parameters
-APP_EXPIRATION_TIME ?= 15
-export APP_EXPIRATION_TIME
-APP_PAGINATION_DEFAULT_LIMIT ?= 10
-export APP_PAGINATION_DEFAULT_LIMIT
-APP_PAGINATION_MAX_LIMIT ?= 100
-export APP_PAGINATION_MAX_LIMIT
-# Enable IS_FAKE_ENABLED for the ephemeral deployment
-APP_ACCEPT_X_RH_FAKE_IDENTITY ?= true
-export APP_ACCEPT_X_RH_FAKE_IDENTITY
-APP_VALIDATE_API ?= true
-export APP_VALIDATE_API
 
-# Set the default token expiration in seconds (2 hours)
-APP_TOKEN_EXPIRATION_SECONDS ?= 7200
-export APP_TOKEN_EXPIRATION_SECONDS
-
-# main secret for various MAC and encryptions like
-# domain registration token and encrypted private JWKs
-APP_SECRET ?= sFamo2ER65JN7wxZ48UZb5GbtDc053ahIPJ0Qx47bzA
-export APP_SECRET


### PR DESCRIPTION
The container-build and compose-build rules were broken, which motivated several changes on this PR:

- Clean-up not needed variables.
- Update Dockerfile to use milti-stage to take advantage of cache layer.
- Add deplo/docker-compose to prepare for local infrastructure.
- Fix container-build rule.
- Fix compose-build.